### PR TITLE
Fix cannot find path "general.spatialfilters"

### DIFF
--- a/odas.cfg
+++ b/odas.cfg
@@ -93,12 +93,15 @@ general:
 
     # Spatial filter to include only a range of direction if required
     # (may be useful to remove false detections from the floor)
-    spatialfilter: {
+    spatialfilters = (
 
-        direction = ( +0.000, +0.000, +1.000 );
-        angle = (80.0, 100.0);
+        {
+            direction = ( +0.000, +0.000, +1.000 );
+            angle = (80.0, 100.0);
 
-    };    
+        }    
+
+    );
 
     nThetas = 181;
     gainMin = 0.25;


### PR DESCRIPTION
I had error with latest ODAS.

```bash
$ ./odaslive -v -c ../../usb_4_mic_array/odas.cfg
...
| + Initializing configurations...... Cannot find path "general.spatialfilters" in config file "../../usb_4_mic_array/odas.cfg"
```
