### PR TITLE
Updated `tuning.py` so it works with Python >=3.2

### DIFF
--- a/tuning.py
+++ b/tuning.py
@@ -106,7 +106,7 @@ class Tuning:
             usb.util.CTRL_IN | usb.util.CTRL_TYPE_VENDOR | usb.util.CTRL_RECIPIENT_DEVICE,
             0, cmd, id, length, self.TIMEOUT)
 
-        response = struct.unpack(b'ii', response.tostring())
+        response = struct.unpack(b'ii', response.tobytes() if sys.version_info[1]>=2 else response.tostring())
 
         if data[2] == 'int':
             result = response[0]


### PR DESCRIPTION
Same issue as occurred in  [ this other Github repo](https://github.com/SecureAuthCorp/impacket/pull/10540)

Essentially, Python3.9 removed the function ```tostring()``` and we now need to use  ```tobytes()```.

The change also includes a check for the minor version to run the new ```tobytes()``` function if we run in 3.2 or higher.

I hope this helps a little and addresses at least [this one forum post.](https://forum.seeedstudio.com/t/tuning-py-is-not-working-with-current-versions-of-python/257312)