### PR TITLE
Modified the usb_4_mic_array python library to be Python 3+ compatible

### DIFF
--- a/dfu.py
+++ b/dfu.py
@@ -154,7 +154,7 @@ class DFU(object):
         data = self._in_request(self.DFU_GETSTATUS, 6)
 
         status = data[0]
-        timeout = data[1] + data[2] << 8 + data[3] << 16
+        timeout = data[1] + (data[2] << 8) + (data[3] << 16)
         state = data[4]
         status_description = data[5]         # index of status description in string table
 
@@ -227,5 +227,3 @@ def main(download, revertfactory):
 
 if __name__ == '__main__':
     main()
-
-

--- a/dfu_windows.py
+++ b/dfu_windows.py
@@ -233,5 +233,3 @@ def main(download, revertfactory):
 
 if __name__ == '__main__':
     main()
-
-

--- a/tuning.py
+++ b/tuning.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 import sys
 import struct
 import usb.core
@@ -11,8 +13,6 @@ USAGE = """Usage: python {} -h
         NAME    get the parameter with the NAME
         NAME VALUE  set the parameter with the NAME and the VALUE
 """
-
-
 
 # parameter list
 # name: (id, offset, type, max, min , r/w, info)
@@ -106,7 +106,7 @@ class Tuning:
             usb.util.CTRL_IN | usb.util.CTRL_TYPE_VENDOR | usb.util.CTRL_RECIPIENT_DEVICE,
             0, cmd, id, length, self.TIMEOUT)
 
-        response = struct.unpack(b'ii', response.tostring())
+        response = struct.unpack(b'ii', response.tobytes())
 
         if data[2] == 'int':
             result = response[0]
@@ -155,7 +155,6 @@ def find(vid=0x2886, pid=0x0018):
     return Tuning(dev)
 
 
-
 def main():
     if len(sys.argv) > 1:
         if sys.argv[1] == '-p':
@@ -165,7 +164,7 @@ def main():
                 data = PARAMETERS[name]
                 print('{:16}\t{}'.format(name, '\t'.join([str(i) for i in data[2:7]])))
                 for extra in data[7:]:
-                    print('{}{}'.format(' '*60, extra))
+                    print('{}{}'.format(' ' * 60, extra))
         else:
             dev = find()
             if not dev:
@@ -184,7 +183,7 @@ def main():
                 if name in PARAMETERS:
                     if len(sys.argv) > 2:
                         dev.write(name, sys.argv[2])
-                    
+
                     print('{}: {}'.format(name, dev.read(name)))
                 else:
                     print('{} is not a valid name'.format(name))
@@ -192,6 +191,7 @@ def main():
             dev.close()
     else:
         print(USAGE.format(sys.argv[0]))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
With the deprecation of Python 2.7 this repo should be modified to be Python 3+ compatible.

For this pull request, I have modified all the Python scripts to make it Python 3+ compatible. This was tested on Python 3.10 and 3.11 but should be compatible with all Python 3.x versions